### PR TITLE
*Fixed problem when decoding non utf8 characters

### DIFF
--- a/QConnectBase/serialclient/serial_base.py
+++ b/QConnectBase/serialclient/serial_base.py
@@ -113,11 +113,11 @@ class SerialSocket(ConnectionBase):
          # implementation from here:
          # http://sourceforge.net/p/pyserial/code/HEAD/tree/trunk/pyserial/examples/rfc2217_server.py
          try:
-            data = self.socket.read(1).decode('utf-8')  # read one, blocking
+            data = self.socket.read(1).decode(self.config.encoding, 'ignore')  # read one, blocking
             n = self.socket.in_waiting  # look if there is more
             if n:
                read_data = self.socket.read(n)
-               data = data + read_data.decode('utf-8')  # and get as much as possible
+               data = data + read_data.decode(self.config.encoding, 'ignore')  # and get as much as possible
             if data:
                for character in data:
                   self.serial_queue.put(character)

--- a/QConnectBase/tcp/ssh/ssh_client.py
+++ b/QConnectBase/tcp/ssh/ssh_client.py
@@ -114,7 +114,7 @@ class SSHClient(TCPBase, TCPBaseClient):
             while self.chan.recv_ready() and not self.chan.closed:
                # data = data + self.chan.recv(1)
                recv = self.chan.recv(1)
-               data = data + recv.decode('utf-8')
+               data = data + recv.decode(self.config.encoding, 'ignore')
 
             for character in data:
                self.SSHq.put(character)

--- a/QConnectBase/utils.py
+++ b/QConnectBase/utils.py
@@ -66,6 +66,7 @@ class DictToClass:
    """
    exclude_list = []
    logfile = None
+   encoding = 'utf-8'
 
    def __init__(self, **dictionary):
       for k, v in dictionary.items():


### PR DESCRIPTION
Fixed https://github.com/test-fullautomation/robotframework-qconnect-base/issues/9:
*Fixed problem when decoding non utf8 characters
+Add parameter 'encoding' to the config for connect keyword